### PR TITLE
Bluetooth: tester: Clear adv_buf after sending GAP_EV_DEVICE_FOUND

### DIFF
--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -570,6 +570,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t evtype,
 	if (adv_buf->len) {
 		tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_FOUND,
 			    CONTROLLER_INDEX, adv_buf->data, adv_buf->len);
+		net_buf_simple_reset(adv_buf);
 	}
 
 	store_adv(addr, rssi, ad);
@@ -584,6 +585,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t evtype,
 done:
 	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_FOUND,
 		    CONTROLLER_INDEX, adv_buf->data, adv_buf->len);
+	net_buf_simple_reset(adv_buf);
 }
 
 static void start_discovery(const uint8_t *data, uint16_t len)


### PR DESCRIPTION
Avoid sending duplicate GAP_EV_DEVICE_FOUND because adv_buf->len was not cleared.

With this change,
the following tests become more stable in a noisy environment:
- GAP/BROB/OBSV/BV-01-C
- GAP/BROB/OBSV/BV-02-C
- GAP/BROB/OBSV/BV-05-C
- GAP/BROB/OBSV/BV-06-C
- GAP/DISC/RPA/BV-01-C

Check attachments:
- before_this_pr: All 5 tests were inconclusive, notice duplicate events + strange protocol messages
- with_this_pr: All 5 tests pass - logs look sane

[before_this_pr.zip](https://github.com/AyturkDuzen/zephyr/files/5423840/before_this_pr.zip)
[with_this_pr.zip](https://github.com/AyturkDuzen/zephyr/files/5423841/with_this_pr.zip)
