### PR TITLE
Bluetooth: tester: Increase DATA_MTU up to the default L2CAP-MPS * 4

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0
-#define DATA_MTU 230
+#define DATA_MTU 264
 #define CHANNELS 2
 #define SERVERS 1
 


### PR DESCRIPTION
When BT_SMP is enabled, the default BT_L2CAP_TX_MTU becomes 65 bytes.
Therefore, the upper tester commands IUT to send up to 256 bytes of
LE data packets to the PTS in L2CAP/LE/CFC/BV-06-C (hdl_wid_57).

Signed-off-by: Chu, Ryan <ryan.chu@nordicsemi.no>