### PR TITLE
Bluetooth: tester: Set the required minimim security level with L2CAP PSM

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -308,6 +308,14 @@ static void listen(uint8_t *data, uint16_t len)
 	server->accept = accept;
 	server->psm = cmd->psm;
 
+	if (server->psm == 0x00F4) {
+		/* TSPX_psm_encryption_key_size_required */
+		server->sec_level = BT_SECURITY_L4;
+	} else if (server->psm == 0x00F2) {
+		/* TSPX_psm_authentication_required */
+		server->sec_level = BT_SECURITY_L3;
+	}
+
 	if (bt_l2cap_server_register(server) < 0) {
 		server->psm = 0U;
 		goto fail;


### PR DESCRIPTION
Bluetooth: tester: Set the required minimim security level with L2CAP PSM

Signed-off-by: Chu, Ryan <ryan.chu@nordicsemi.no>